### PR TITLE
Similarity db generator

### DIFF
--- a/bin/similarity-db
+++ b/bin/similarity-db
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+trap 'exit 1' ERR
+
+ROOT=$(realpath $(dirname ${BASH_SOURCE[0]})/..)
+APP_FOLDER=$ROOT/src/torch
+
+if [ ! -z "$1" ]; then
+  if [ "$1" != "--config" ]; then
+    echo $"Usage: $0 [--config /path/to/config/file]" 1>&2
+    exit 1
+  elif [ ! -f "$2" ]; then
+    echo "missing config file: $2" 1>&2
+    exit 1
+  fi
+
+  CONFIG="-config $2"
+fi
+
+export TIEFVISION_HOME=$ROOT
+
+echo "Fetching models"
+download () {
+  url=https://s3.amazonaws.com/gilt-ml/$1
+  output=$ROOT/$2
+
+  mkdir -p $(dirname $output)
+
+  curl $url --output $output --silent
+}
+
+download caffe-zoo-mirror/ilsvrc_2012_mean.t7 src/torch/models/ilsvrc_2012_mean.t7
+download caffe-zoo-mirror/synset_words.txt src/torch/models/synset_words.txt
+download caffe-zoo-mirror/nin_imagenet.caffemodel src/torch/1-split-encoder-classifier/nin_imagenet.caffemodel
+download caffe-zoo-mirror/Goldfish3.jpg src/torch/1-split-encoder-classifier/Goldfish3.jpg
+
+echo "Generating encoder"
+luajit $APP_FOLDER/1-split-encoder-classifier/split-encoder-classifier.lua $CONFIG
+
+echo "Generating image encoding"
+luajit $APP_FOLDER/8-similarity-db-cnn/generate-similarity-db.lua $CONFIG
+
+echo "Generating image similarities"
+luajit $APP_FOLDER/9-similarity-db/similarity-db.lua $CONFIG

--- a/bin/similarity-db
+++ b/bin/similarity-db
@@ -38,7 +38,12 @@ echo "Generating encoder"
 luajit $APP_FOLDER/1-split-encoder-classifier/split-encoder-classifier.lua $CONFIG
 
 echo "Generating image encoding"
-luajit $APP_FOLDER/8-similarity-db-cnn/generate-similarity-db.lua $CONFIG
+luajit $APP_FOLDER/8-similarity-db-cnn/generate-similarity-db.lua \
+  -sources $ROOT/resources/dresses-db/master \
+  -destinations $ROOT/resources/dresses-db/encoded-images \
+  $CONFIG
 
 echo "Generating image similarities"
-luajit $APP_FOLDER/9-similarity-db/similarity-db.lua $CONFIG
+luajit $APP_FOLDER/9-similarity-db/similarity-db.lua \
+  -images $ROOT/resources/dresses-db/encoded-images \
+  $CONFIG

--- a/src/torch/0-tiefvision-commons/tiefvision_commons.lua
+++ b/src/torch/0-tiefvision-commons/tiefvision_commons.lua
@@ -47,7 +47,7 @@ end
 
 -- Loads the mapping from net outputs to human readable labels
 function tiefvision_commons.load_synset()
-  local file = io.open 'synset_words.txt'
+  local file = io.open(tiefvision_commons.modelPath('synset_words.txt'))
   local list = {}
   while true do
     local line = file:read()

--- a/src/torch/1-split-encoder-classifier/split-encoder-classifier.lua
+++ b/src/torch/1-split-encoder-classifier/split-encoder-classifier.lua
@@ -8,7 +8,8 @@
 -- to encode images.
 --
 
-local torchFolder = require('paths').thisfile('..')
+local paths = require('paths')
+local torchFolder = paths.thisfile('..')
 package.path = string.format("%s;%s/?.lua", os.getenv("LUA_PATH"), torchFolder)
 
 require 'image'
@@ -19,9 +20,9 @@ local torch = require 'torch'
 
 local tiefvision_commons = require '0-tiefvision-commons/tiefvision_commons'
 
-local proto_name = 'deploy.prototxt'
-local model_name = 'nin_imagenet.caffemodel'
-local image_name = 'Goldfish3.jpg'
+local proto_name = paths.thisfile('deploy.prototxt')
+local model_name = paths.thisfile('nin_imagenet.caffemodel')
+local image_name = paths.thisfile('Goldfish3.jpg');
 
 local net = loadcaffe.load(proto_name, model_name):cuda()
 net.modules[#net.modules] = nil -- remove the top softmax

--- a/src/torch/7-bboxes-images/bboxes-images.lua
+++ b/src/torch/7-bboxes-images/bboxes-images.lua
@@ -2,7 +2,8 @@
 -- You may use, distribute and modify this code under the
 -- terms of the Apache License v2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt).
 
-local torchFolder = require('paths').thisfile('..')
+local paths = require('paths')
+local torchFolder = paths.thisfile('..')
 package.path = string.format("%s;%s/?.lua", os.getenv("LUA_PATH"), torchFolder)
 
 require 'inn'
@@ -41,11 +42,16 @@ for fileIndex = 1, #files do
       local xmax = bboxes[i][3]
       local ymax = bboxes[i][4]
       print(xmin, ymin, xmax, ymax)
+
       local inputCropped = image.crop(input, xmin, ymin, xmax, ymax)
+      paths.mkdir(bboxesFolder .. '/' .. i)
       image.save(bboxesFolder .. '/' .. i .. '/' .. files[fileIndex], inputCropped)
+
       -- generate flipped images
       local flippedInput = image.hflip(inputCropped)
+      paths.mkdir(flippedBboxesFolder .. '/' .. i)
       image.save(flippedBboxesFolder .. '/' .. i .. '/' .. files[fileIndex], flippedInput)
+
       collectgarbage()
     end
   end

--- a/src/torch/8-similarity-db-cnn/generate-similarity-db.lua
+++ b/src/torch/8-similarity-db-cnn/generate-similarity-db.lua
@@ -2,7 +2,8 @@
 -- You may use, distribute and modify this code under the
 -- terms of the Apache License v2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt).
 
-local torchFolder = require('paths').thisfile('..')
+local paths = require('paths')
+local torchFolder = paths.thisfile('..')
 package.path = string.format("%s;%s/?.lua", os.getenv("LUA_PATH"), torchFolder)
 
 require 'inn'
@@ -21,6 +22,8 @@ local function createDb(sourceFolder, destinationFolder)
   for fileIndex = 1, #files do
     local file = files[fileIndex]
     local destPath = destinationFolder .. '/' .. file
+
+    paths.mkdir(destinationFolder)
     if(not tiefvision_commons.fileExists(destPath)) then
       print('Encoding ' .. file)
       local encoderOutput = similarity_db_lib.encodeImage(sourceFolder .. '/' .. file, encoder)


### PR DESCRIPTION
A single executable to to run image similarity. This will fetch or generate the required dependencies.

The image cropping has been removed for two main reasons:
- it required human interaction
- the result from a cropped and uncropped run are similar
- changing from dress to [shoes, shirts, handbags, ...] would require retraining the cropping

Will be looking into injecting image paths next. `ROOT/resources/dresses-db/master` is quite limitting 